### PR TITLE
Log original error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules/
 
 target
 jenkins
+npm-debug.log

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,6 +29,8 @@ builder.bundle('spec/testmodule.js', 'testmodule_2')
 builder.bundle('spec/testmodule.js', 'testmodule_3')
     .import('underscore.string', {addDefaultCSS: true})
     .inDir('target/testmodule')
+    .onStartup('./spec/startup-module-1.js')
+    .onStartup('./spec/startup-module-2.js')
     .generateNoImportsBundle();
 
 //  - bundle "as" with a version - no prerelease tag 

--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ exports.defineTasks = function(tasknames) {
     }
 
     if (defaults.length > 0) {
-        logger.logInfo('Defining default tasks...');
+        logger.logInfo('Defining default tasks: ' + defaults);
         gulp.task('default', defaults);
     }
 };

--- a/index.js
+++ b/index.js
@@ -319,6 +319,8 @@ function bundleJs(moduleToBundle, as) {
     bundle.useGlobalImportMappings = true;
     bundle.useGlobalExportMappings = true;
     bundle.minifyBundle = args.isArgvSpecified('--minify');
+    bundle.startupModules = [];
+
     bundle.generateNoImportsBundle = function() {
         if (skipBundle) {
             return bundle;
@@ -441,7 +443,7 @@ function bundleJs(moduleToBundle, as) {
                 // This is the "traditional" export use case.
                 bundle.bundleExport = true;
                 bundle.bundleExportNamespace = packageJson.name;
-            } else if (dependencies.getDependency(moduleName) !== undefined) {
+            } else if (dependencies.getDependency(moduleName, false) !== undefined) {
                 // We are exporting some dependency of this module Vs exporting
                 // the top/entry level module of the generated bundle. This allows the bundle
                 // to control loading of a specific dependency (or set of) and then share that with
@@ -489,6 +491,13 @@ function bundleJs(moduleToBundle, as) {
             }
         }
         return undefined;
+    };
+
+    bundle.onStartup = function (startupModule) {
+        if (typeof startupModule === 'string') {
+            bundle.startupModules.push(startupModule);
+        }
+        return bundle;
     };
 
     if (skipBundle) {

--- a/internal/bundlegen.js
+++ b/internal/bundlegen.js
@@ -261,8 +261,9 @@ exports.doCSSBundle = function(bundle, resource) {
 
 function less(src, targetDir) {
     var less = require('gulp-less');
+    // Run less with the ieCompat option switched off. Sorry, but we don't care about IE8 !!!
     gulp.src(src)
-        .pipe(less().on('error', function (err) {
+        .pipe(less({ieCompat: false}).on('error', function (err) {
             logger.logError('LESS processing error:');
             if (err) {
                 logger.logError('\tmessage: ' + err.message);

--- a/internal/maven.js
+++ b/internal/maven.js
@@ -27,8 +27,7 @@ exports.getPackaging = function() {
 };
 
 exports.isHPI = function() {
-    assertIsMavenProject();
-    return (exports.getPackaging() === 'hpi');
+    return (exports.isMavenProject && exports.getPackaging() === 'hpi');
 };
 
 function assertIsMavenProject(preamble) {

--- a/internal/templates/entry-module-wrapper.js
+++ b/internal/templates/entry-module-wrapper.js
@@ -22,6 +22,7 @@ promise.make(function(fulfill) {
         var startupModule = require('{{this}}');
         startupModule.execute(fulfill, config);
     } catch (e) {
+        console.error(e);
         throw new Error('Unexpected error executing startup module "{{this}}": ' + e);
     }
 }).onFulfilled(function() {

--- a/internal/templates/entry-module-wrapper.js
+++ b/internal/templates/entry-module-wrapper.js
@@ -1,0 +1,30 @@
+var promise = require("@jenkins-cd/js-modules/js/promise");
+
+var numStartupModules = {{startupModules.length}};
+var fullfilled = [];
+var config = {
+    hpiPluginId: {{#if hpiPluginId}}'{{hpiPluginId}}'{{else}}undefined{{/if}}
+};
+
+function onFullfilled(moduleName) {
+    if (fullfilled.indexOf(moduleName) === -1) {
+        fullfilled.push(moduleName);
+    }
+    if (fullfilled.length === numStartupModules) {
+        require('{{entrymodule}}');
+        onExec();
+    }
+}
+
+{{#each startupModules}}
+promise.make(function(fulfill) {
+    try {
+        var startupModule = require('{{this}}');
+        startupModule.execute(fulfill, config);
+    } catch (e) {
+        throw new Error('Unexpected error executing startup module "{{this}}": ' + e);
+    }
+}).onFulfilled(function() {
+    onFullfilled('{{this}}');
+});
+{{/each}}

--- a/internal/templates/entry-module.hbs
+++ b/internal/templates/entry-module.hbs
@@ -3,8 +3,9 @@ var ___$$$___jsModules = require('@jenkins-cd/js-modules');
 ___$$$___jsModules.whoami('{{#if bundle.bundleExportNamespace}}{{bundle.bundleExportNamespace}}:{{/if}}{{bundle.as}}');
 
 /*** Start Module Exec Function ***************************************/
-function ___$$$___exec() {
+function ___$$$___exec(onExec) {
     {{content}}
+    {{#if bundle.doOnExecCall}}onExec();{{/if}}
 }
 /*** End Module Exec Function   ***************************************/
 
@@ -39,9 +40,10 @@ function ___$$$___doCSS() {
 
 function ___$$$___doBundleInit() {
     try {
-        ___$$$___exec();
-        ___$$$___doExports();
-        ___$$$___doCSS();
+        ___$$$___exec(function() {
+            ___$$$___doExports();
+            ___$$$___doCSS();
+        });
     } catch (e) {
         console.error('Error initializing Jenkins JavaScript bundle "{{bundle.as}}"', e);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-builder",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "description": "Jenkins CI JavaScript Build utilities.",
   "main": "index.js",
   "scripts": {
@@ -47,7 +47,7 @@
     "gulp-jasmine": "^2.0.1",
     "gulp-jshint": "^2.x",
     "gulp-less": "^1.3.6",
-    "gulp-runner": "^0.1.4",
+    "gulp-runner": "^1.0.0",
     "gulp-util": "^3.0.6",
     "handlebars": "^3.0.3",
     "jasmine-reporters": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-builder",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "description": "Jenkins CI JavaScript Build utilities.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-builder",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "description": "Jenkins CI JavaScript Build utilities.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-builder",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "description": "Jenkins CI JavaScript Build utilities.",
   "main": "index.js",
   "scripts": {

--- a/spec/startup-module-1.js
+++ b/spec/startup-module-1.js
@@ -1,0 +1,4 @@
+
+exports.execute = function(done, config) {
+    done();
+};

--- a/spec/startup-module-2.js
+++ b/spec/startup-module-2.js
@@ -1,0 +1,4 @@
+
+exports.execute = function(done, config) {
+    done();
+};


### PR DESCRIPTION
When there's an exception thrown initialising the system, log the original error to the console so the developer can see what actually happened, rather than only getting the stack trace of the re-throw.