### PR TITLE
fix bug where gulp-mocha can hang after test run

### DIFF
--- a/internal/tests.js
+++ b/internal/tests.js
@@ -119,6 +119,9 @@ function mochaTestTask() {
                 return;
             }
             process.exit(1);
+        }) // https://github.com/sindresorhus/gulp-mocha#test-suite-not-exiting
+        .once('end', function () {
+          process.exit();
         });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-builder",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "description": "Jenkins CI JavaScript Build utilities.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes bug where `gulp-mocha` can fail to exit after a test run https://github.com/sindresorhus/gulp-mocha#test-suite-not-exiting 

PTAL @tfennelly @cliffmeyers 